### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "tflite"
+description := "A free and open-source software library for machine learning and artificial intelligence."
+gitrepo     := "https://github.com/tensorflow/tensorflow.git"
+homepage    := "https://www.tensorflow.org/"
+license     := "Apache-2.0"
+version     := 2.0.1 29197d30923b9670992ee4b9c6161f50c7452e9a4158c720746e846080ac245a https://github.com/tensorflow/tensorflow/archive/v2.0.1.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

